### PR TITLE
Fix: Resolve permission error with storage directories in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     working_dir: /var/www
     volumes:
       - .:/var/www
+      - cache_data:/var/www/storage
+      - logs_data:/var/www/bootstrap/cache
     environment:
       - DB_HOST=db
       - DB_PORT=3306
@@ -53,3 +55,5 @@ services:
 
 volumes:
   dbdata:
+  cache_data:
+  logs_data:


### PR DESCRIPTION
Adjusted docker-compose.yml to use Docker volumes for /var/www/storage and /var/www/bootstrap/cache directories, resolving permission denied errors when the application writes to these directories